### PR TITLE
Bugfix basePath resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ var createLessPreprocessor = function (args, config, basePath, logger, helper) {
   };
 
   return function (content, file, done) {
-	var translatedPaths = Array();
+    var translatedPaths = Array();
     file.path = transformPath(file.originalPath);
 
     for (importPath in options.paths) {


### PR DESCRIPTION
Since the preprocessor gets called with every file it has to process, the basePath resolution went corrupt if two or more less files had to be processed. Now it uses a second array to store the resolved paths.
Sorry for this bug in my last request.
