### PR TITLE
log error details

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var createLessPreprocessor = function (args, configuration, basePath, logger, he
   var rendered = function (done, filePath, error, css) {
     var content;
     if (error !== null && error !== undefined) {
-      log.error('Error:%s\n', error);
+      log.error('Error parsing file:', error);
     } else {
       content = css.toCSS({compress: options.compress})
       if (options.save) {
@@ -27,7 +27,7 @@ var createLessPreprocessor = function (args, configuration, basePath, logger, he
           var n = filePath.match(/[a-zA-Z\-\.\_]+.css$/).reverse()[0];
           fs.writeFile(path.join(p, n), content, 'utf-8', function (error) {
             if (error) {
-              log.error('Error:%s', error);
+              log.error('Error writing file:', error);
             }
             done(content);
           });
@@ -40,7 +40,7 @@ var createLessPreprocessor = function (args, configuration, basePath, logger, he
 
   return function (content, file, done) {
     file.path = transformPath(file.originalPath);
-		
+
     options.paths.forEach(function(element, index, array) {
       translatedPaths[index] = basePath + '/' + element;
     });


### PR DESCRIPTION
Let logger print the error details given an error object will full details. (’%s’, error)
as of now it just prints [Object object] which makes it difficult to debug issues like Issue #10 