### PR TITLE
Updating to less ~2.5

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var less = require('less'),
-    Parser = less.Parser,
     path = require('path'),
     fs = require('fs'),
     util = require('util');
@@ -15,12 +14,12 @@ var createLessPreprocessor = function (args, configuration, basePath, logger, he
     return filePath.replace(/\.less$/, '.css');
   };
 
-  var rendered = function (done, filePath, error, css) {
+  var rendered = function (done, filePath, error, content) {
     var content;
     if (error !== null && error !== undefined) {
       log.error('Error:%s\n', error);
     } else {
-      content = css.toCSS({compress: options.compress})
+      content = content.css;
       if (options.save) {
         var p = path.resolve(filePath.replace(/\/([\.a-zA-Z0-9\-\_]+).css$/, '/'));
         helper.mkdirIfNotExists(p, function () {
@@ -45,12 +44,12 @@ var createLessPreprocessor = function (args, configuration, basePath, logger, he
       translatedPaths[index] = basePath + '/' + element;
     });
 
-    var parser = new Parser(util._extend({}, options, {
+    var fullOptions = util._extend({}, options, additionalData, {
       paths: translatedPaths,
-    }));
+    });
 
     try {
-      parser.parse(content, rendered.bind(null, done, file.path), additionalData);
+      less.render(content, fullOptions, rendered.bind(null, done, file.path));
     } catch (error) {
       log.error('%s\n  at %s', error.message, file.originalPath);
       return;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "author": "David Sergey <nirth.furzahad@gmail.com>, Cloud Chen <cloudcmh@gmail.com>",
   "dependencies": {
-    "less": "~1.7"
+    "less": "~2.5"
   },
   "peerDependencies": {
     "karma": ">=0.10"


### PR DESCRIPTION
This is my attempt at updating to less 2+.  Seems to be working fine for my project but that only make use of `options.paths` and `transformPath`...

`less.Parser` [has been depricated](http://lesscss.org/usage/#v2-upgrade-guide-programmatic-usage) and has also changed enough that it doesn't work the same as 1.x. It seemed easiest to just use `less.render` like the upgrade guide says.